### PR TITLE
Export package.json to support usage in React Native 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		"./package.json": "./package.json",
+		".": "./index.js"
+	},
 	"engines": {
 		"node": ">=12"
 	},


### PR DESCRIPTION
Adding `sdbm` to a RN project results in a build warning:

```
warn Package sdbm has been ignored because it contains invalid configuration. Reason: Package subpath './package.json' is not defined by "exports" in node_modules/sdbm/package.json
```

I assume this is due to `require.resolve` usage somewhere, where the `exports` in the current package.json prevents importing `package.json` itself. To fix this we need to either remove the `exports` field, or expose package.json explicitly, which I've done here.

This has been popping up in a ton of different repos since node 14 came out.